### PR TITLE
Automatically install requirements from pypi and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ If you want to run the entire processing pipeline in one go, look at the run_pro
 
 **NEW: checkout the new interface to automatically run the entire pipeline or subsets of it on multiple flies [here](twoppp/run/README.md):**
 
-Installation instructions:
+## Installation instructions:
+### pure pip
+
+   pip install numpy
+   pip install -e .
+
+### conda
 1. Create conda environment and install required packages according to their respective install instructions:
     - ```conda create -n twoppp37 python=3.7```
     - ```conda activate twoppp37```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+jupyter
+deepfly @ https://github.com/NeLy-EPFL/DeepFly3D/archive/twoppp-compatible.tar.gz
+deepinterpolation @ https://github.com/NeLy-EPFL/deepinterpolation/archive/adapttoR57C10.tar.gz
+numpy
+pandas
+utils2p @ git+https://github.com/NeLy-EPFL/utils2p.git
+ofco @ git+https://github.com/NeLy-EPFL/ofco.git
+utils_video @ git+https://github.com/NeLy-EPFL/utils_video.git
+df3dPostProcessing @ git+https://github.com/NeLy-EPFL/df3dPostProcessing.git
+behavelet

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,11 @@
 from setuptools import setup, find_packages
 
-try:
-    import utils2p
-except ImportError or ModuleNotFoundError:
-    raise ImportError("utils2p must be installed in environment.")
-
-try:
-    from deepfly.CameraNetwork import CameraNetwork
-except ImportError or ModuleNotFoundError:
-    raise ImportError("deepfly must be installed in environment.")
-
-try:
-    from deepinterpolation import interface as denoise
-
-except ImportError or ModuleNotFoundError:
-    raise ImportError("DeepInterpolation must be installed in environment.")
-
-try:
-    import ofco
-except ImportError or ModuleNotFoundError:
-    raise ImportError("ofco must be installed in environment.")
-
-try:
-    import utils_video
-except ImportError or ModuleNotFoundError:
-    raise ImportError("utils_video must be installed in environment.")
-
-try:
-    import df3dPostProcessing
-except ImportError or ModuleNotFoundError:
-    raise ImportError("df3dPostProcessing must be installed in environment.")
-
-try:
-    import behavelet
-except ImportError or ModuleNotFoundError:
-    raise ImportError("behavelet must be installed in environment.")
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+with open("requirements.txt", "r") as f:
+    requirements = f.read().splitlines()
+    requirements = [l for l in requirements if not l.startswith('#')]
 
 setup(
     name="twoppp",
@@ -57,4 +25,5 @@ setup(
     # long_description=long_description,
     long_description_content_type="text/x-rst",
     url="https://github.com/NeLy-EPFL/twoppp",
+    install_requires=requirements,
 )


### PR DESCRIPTION
As the README now says, this package can be installed by just:

    pip install numpy
    pip install -e .

And all other dependencies will be installed as part of this command.

I haven't tested whether this sort of thing words in conda because I try to not touch conda whenever possible. If it does work (or works with some small modifications), we can strip the long conda install instructions out of the readme.